### PR TITLE
add hermez-network information

### DIFF
--- a/data_pipeline/config.json
+++ b/data_pipeline/config.json
@@ -62,6 +62,24 @@
       "stablecoin": false,
       "decimals": 18,
       "coinpaprika_id": "link-chainlink"
+    },
+    "WETH": {
+      "address": "0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2",
+      "stablecoin": false,
+      "decimals": 18,
+      "coinpaprika_id": "weth-weth"
+    },
+    "UNI": {
+      "address": "0x1f9840a85d5aF5bf1D1762F925BDADdC4201F984",
+      "stablecoin": false,
+      "decimals": 18,
+      "coinpaprika_id": "uni-uniswap"
+    },
+    "YFI": {
+      "address": "0x0bc529c00C6401aEF6D220BE8C6Ea1667F6Ad93e",
+      "stablecoin": false,
+      "decimals": 18,
+      "coinpaprika_id": "yfi-yearnfinance"
     }
   },
   "l2s": {
@@ -125,6 +143,15 @@
           "address": "0x5FDCCA53617f4d2b9134B29090C87D01058e27e9",
           "deployed_at_block": 12011518,
           "tokens": ["ETH"]
+        }
+      ]
+    },
+    "Hermez": {
+      "bridges": [
+        {
+          "address": "0xA68D85dF56E733A06443306A095646317B5Fa633",
+          "deployed_at_block": 12093596,
+          "tokens": ["ETH", "USDT", "USDC", "DAI", "WBTC", "WETH", "UNI", "YFI", "LINK"]
         }
       ]
     }

--- a/frontend/data/projects-data.json
+++ b/frontend/data/projects-data.json
@@ -256,5 +256,51 @@
         "link": "https://www.immutable.com/blog/immutable-x-alpha-trading-launch"
       }
     ]
+  },
+  "Hermez": {
+    "website": "https://hermez.io/",
+    "color": "#ff9933",
+    "technology": "zk-rollup",
+    "technology-details": "zk-SNARK",
+    "more-info": {
+      "Primary use case": { "text": "Payments" },
+      "Hypothetical level of decentralization": { "text": "High", "sentiment": "good" },
+      "Current level of decentralization": { "text": "Low", "tooltip": "Contracts are upgradable", "sentiment": "bad" },
+      "Can funds be stolen by the operator?": {
+        "text": "Yes, through contract upgrade",
+        "tooltip": "Contracts are upgradable BUT on the upside there is a 7 days timelock",
+        "sentiment": "neutral",
+        "pointers": ["https://etherscan.io/address/0xA68D85dF56E733A06443306A095646317B5Fa633#code"]
+      },
+      "Permisonless?": {
+        "text": "No",
+        "sentiment": "bad",
+        "tooltip": "After initial bootstraping period anyone could bid for a slot time to forge new batches and update the state root",
+        "pointers": [
+          "https://github.com/hermeznetwork/contracts/blob/master/contracts/auction/HermezAuctionProtocol.sol#L515",
+          "https://github.com/hermeznetwork/contracts/blob/master/contracts/auction/HermezAuctionProtocol.sol#L571",
+          "https://docs.hermez.io/#/developers/protocol/consensus/consensus"
+        ]
+      },
+      "Force TX mechanism?": {
+        "text": "Yes",
+        "sentiment": "good",
+        "tooltip": "Transaction can be forced via smart contract. Coordinators must process them",
+        "pointers": [
+          "https://github.com/hermeznetwork/contracts/blob/master/contracts/hermez/Hermez.sol#L361",
+          "https://docs.hermez.io/#/developers/protocol/hermez-protocol/protocol?id=l1-user-transactions"
+        ]
+      },
+      "Privacy": { "text": "No" },
+      "Smart contracts": {
+        "text": "No"
+      }
+    },
+    "news": [
+      {
+        "name": "Hermez Network Mainnet Launch on 4th of March 2021",
+        "link": "https://blog.hermez.io/hermez-network-mainnet-launch/"
+      }
+    ]
   }
 }


### PR DESCRIPTION
This PR add the following:
- adds tokens `WETH`, `UNI`, `YFI`
- add hermez config file in `bridges`
- add frontend project information

Close #55

>important note: HEZ token is not supported by `https://api.coinpaprika.com/v1/coins`. Therefore, all value locked in `hermez-network` does not include HEZ locked tokens